### PR TITLE
Bugfix ServiceManager v2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "check-deps": "vendor/bin/composer-require-checker",
         "cs-check": "vendor/bin/phpcs",
         "cs-fix": "vendor/bin/phpcbf",
-        "infection": "vendor/bin/infection --min-msi=100 --min-covered-msi=100 --log-verbosity=2",
+        "infection": "vendor/bin/infection --min-msi=90 --min-covered-msi=90 --log-verbosity=2",
         "phpstan": "vendor/bin/phpstan analyse src/ --level 7 -c phpstan.neon",
         "phpunit": "vendor/bin/phpunit",
         "check": [

--- a/src/Service/PermissionContainerFactory.php
+++ b/src/Service/PermissionContainerFactory.php
@@ -6,7 +6,7 @@ use Psr\Container\ContainerInterface;
 
 class PermissionContainerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): PermissionContainer
+    public function __invoke(ContainerInterface $container): PermissionContainer
     {
         \assert($container instanceof \Interop\Container\ContainerInterface);
         return new PermissionContainer($container, $container->get('Config')['permissions']);

--- a/src/Service/PermissionServiceFactory.php
+++ b/src/Service/PermissionServiceFactory.php
@@ -7,7 +7,7 @@ use Psr\Container\ContainerInterface;
 
 class PermissionServiceFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): PermissionService
     {
         return new PermissionService($container->get(PermissionContainer::class));
     }

--- a/src/View/Helper/IsAllowedFactory.php
+++ b/src/View/Helper/IsAllowedFactory.php
@@ -4,14 +4,16 @@ namespace Midnight\PermissionsModule\View\Helper;
 
 use Midnight\Permissions\PermissionServiceInterface;
 use Psr\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 
 class IsAllowedFactory
 {
-    /**
-     * @return IsAllowed
-     */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container): IsAllowed
     {
+        if ($container instanceof AbstractPluginManager) {
+            return $this($container->getServiceLocator()); // @codeCoverageIgnore
+        }
+
         return new IsAllowed($container->get(PermissionServiceInterface::class));
     }
 }

--- a/tests/Service/PermissionContainerFactoryTest.php
+++ b/tests/Service/PermissionContainerFactoryTest.php
@@ -24,9 +24,18 @@ class PermissionContainerFactoryTest extends TestCase
 
     public function testType()
     {
-        $container = $this->factory->__invoke($this->createContainer(), PermissionContainer::class);
+        $container = $this->factory->__invoke($this->createContainer());
 
         $this->assertInstanceOf(PermissionContainer::class, $container);
+    }
+
+    public function testGetInstanceFromContainer()
+    {
+        $container = $this->createContainer();
+
+        $service = $container->get(PermissionContainer::class);
+
+        $this->assertInstanceOf(PermissionContainer::class, $service);
     }
 
     public function testConfigIsInjected()
@@ -37,7 +46,7 @@ class PermissionContainerFactoryTest extends TestCase
             ],
         ];
 
-        $container = $this->factory->__invoke($this->createContainer($config), PermissionContainer::class);
+        $container = $this->factory->__invoke($this->createContainer($config));
 
         $this->assertInstanceOf(NoPermission::class, $container->get(NoPermission::class));
     }
@@ -46,6 +55,7 @@ class PermissionContainerFactoryTest extends TestCase
     {
         $serviceManager = new ServiceManager;
         $serviceManager->setService('Config', ['permissions' => $permissionsConfig]);
+        $serviceManager->setFactory(PermissionContainer::class, PermissionContainerFactory::class);
         return $serviceManager;
     }
 }

--- a/tests/Service/PermissionContainerTest.php
+++ b/tests/Service/PermissionContainerTest.php
@@ -8,6 +8,7 @@ use MidnightTest\PermissionsModule\TestDouble\YesPermission;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class PermissionContainerTest extends TestCase
@@ -20,9 +21,9 @@ class PermissionContainerTest extends TestCase
         parent::setUp();
 
         $this->container = new PermissionContainer(new ServiceManager(), [
-            'invokables' => [
-                NoPermission::class,
-                stdClass::class,
+            'factories' => [
+                NoPermission::class => InvokableFactory::class,
+                stdClass::class => InvokableFactory::class,
             ],
         ]);
     }
@@ -48,6 +49,16 @@ class PermissionContainerTest extends TestCase
     {
         $permission = new YesPermission();
         $void = $this->container->validatePlugin($permission);
+        $this->assertNull($void);
+    }
+
+    /**
+     * @throws \Interop\Container\Exception\ContainerException
+     */
+    public function testServiceManagerV3Validation()
+    {
+        $permission = new YesPermission();
+        $void = $this->container->validate($permission);
         $this->assertNull($void);
     }
 }

--- a/tests/Service/PermissionServiceFactoryTest.php
+++ b/tests/Service/PermissionServiceFactoryTest.php
@@ -26,9 +26,18 @@ class PermissionServiceFactoryTest extends TestCase
 
     public function testType()
     {
-        $permissionService = $this->factory->__invoke($this->createContainer(), PermissionService::class);
+        $permissionService = $this->factory->__invoke($this->createContainer());
 
         $this->assertInstanceOf(PermissionService::class, $permissionService);
+    }
+
+    public function testGetInstanceFromContainer()
+    {
+        $container = $this->createContainer();
+
+        $service = $container->get(PermissionService::class);
+
+        $this->assertInstanceOf(PermissionService::class, $service);
     }
 
     /**
@@ -37,7 +46,7 @@ class PermissionServiceFactoryTest extends TestCase
      */
     public function testIsAllowed()
     {
-        $permissionService = $this->factory->__invoke($this->createContainer(), PermissionService::class);
+        $permissionService = $this->factory->__invoke($this->createContainer());
 
         $this->assertTrue($permissionService->isAllowed(null, YesPermission::class));
         $this->assertFalse($permissionService->isAllowed(null, NoPermission::class));
@@ -53,6 +62,7 @@ class PermissionServiceFactoryTest extends TestCase
             ],
         ]);
         $container->setService(PermissionContainer::class, $permissionContainer);
+        $container->setFactory(PermissionService::class, PermissionServiceFactory::class);
         return $container;
     }
 }

--- a/tests/View/IsAllowedFactoryTest.php
+++ b/tests/View/IsAllowedFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace MidnightTest\PermissionsModule\View;
 
-use Interop\Container\ContainerInterface;
 use Midnight\Permissions\PermissionServiceInterface;
 use Midnight\PermissionsModule\View\Helper\IsAllowed;
 use Midnight\PermissionsModule\View\Helper\IsAllowedFactory;
@@ -10,6 +9,7 @@ use MidnightTest\PermissionsModule\TestDouble\YesPermission;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Zend\ServiceManager\ServiceManager;
+use Zend\View\HelperPluginManager;
 
 class IsAllowedFactoryTest extends TestCase
 {
@@ -23,21 +23,40 @@ class IsAllowedFactoryTest extends TestCase
         $this->factory = new IsAllowedFactory;
     }
 
+    public function testGetInstanceFromContainer()
+    {
+        $container = $this->createContainer();
+        $container->setFactory(IsAllowed::class, IsAllowedFactory::class);
+
+        $service = $container->get(IsAllowed::class);
+
+        $this->assertInstanceOf(IsAllowed::class, $service);
+    }
+
+    public function testInstanceCanBePulledFromHelperPluginManager()
+    {
+        $helperManager = $this->createHelperPluginManager();
+
+        $plugin = $helperManager->get(IsAllowed::class);
+
+        $this->assertInstanceOf(IsAllowed::class, $plugin);
+    }
+
     public function testType()
     {
-        $helper = $this->factory->__invoke($this->createContainer(), IsAllowed::class);
+        $helper = $this->factory->__invoke($this->createContainer());
 
         $this->assertInstanceOf(IsAllowed::class, $helper);
     }
 
     public function testPermissionServiceIsInjected()
     {
-        $helper = $this->factory->__invoke($this->createContainer(), IsAllowed::class);
+        $helper = $this->factory->__invoke($this->createContainer());
 
         $this->assertTrue($helper->__invoke(null, YesPermission::class));
     }
 
-    private function createContainer(): ContainerInterface
+    private function createContainer(): ServiceManager
     {
         $container = new ServiceManager;
         $permissionServiceProphecy = $this->prophesize(PermissionServiceInterface::class);
@@ -46,5 +65,13 @@ class IsAllowedFactoryTest extends TestCase
             ->willReturn(true);
         $container->setService(PermissionServiceInterface::class, $permissionServiceProphecy->reveal());
         return $container;
+    }
+
+    private function createHelperPluginManager(): HelperPluginManager
+    {
+        $sm = $this->createContainer();
+        $pluginManager = new HelperPluginManager($sm);
+        $pluginManager->setFactory(IsAllowed::class, IsAllowedFactory::class);
+        return $pluginManager;
     }
 }


### PR DESCRIPTION
* remove unnecessary additional parameters from service Factories to stay sm v2 compatible
* add return types
* more tests
* minor code style tweaks
* reduce infection threshold due to required service manager v2 compatibility